### PR TITLE
[Sync] Update project files from source repository (ffbafef)

### DIFF
--- a/.github/actions/cache-redis-image/action.yml
+++ b/.github/actions/cache-redis-image/action.yml
@@ -126,7 +126,7 @@ runs:
     - name: 💾 Restore Redis image from cache
       if: contains(inputs.cache-mode, 'restore')
       id: restore-redis-image
-      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ steps.cache-config.outputs.cache-path }}
         key: ${{ steps.cache-config.outputs.cache-key }}
@@ -222,7 +222,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 🗄️ Save Redis image cache
       if: contains(inputs.cache-mode, 'save') && steps.save-redis-image.outputs.image-saved == 'true' && steps.restore-redis-image.outputs.cache-hit != 'true'
-      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ${{ steps.cache-config.outputs.cache-path }}
         key: ${{ steps.cache-config.outputs.cache-key }}

--- a/.github/actions/setup-benchstat/action.yml
+++ b/.github/actions/setup-benchstat/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: "Runner OS for cache key (e.g., ubuntu-latest, mac-latest)"
     required: true
   go-version:
-    description: "Go version being used (e.g., 1.24.x, 1.22). Benchstat requires Go 1.23+"
+    description: "Go version being used (e.g., 1.25.x, 1.24). Benchstat requires Go 1.25+"
     required: true
 
 outputs:
@@ -44,14 +44,14 @@ outputs:
     description: "How benchstat was obtained: cached, fresh, or skipped"
     value: ${{ steps.installation-summary.outputs.method }}
   skipped:
-    description: "Whether benchstat installation was skipped due to Go version < 1.23"
+    description: "Whether benchstat installation was skipped due to Go version < 1.25"
     value: ${{ steps.version-check.outputs.skip }}
 
 runs:
   using: "composite"
   steps:
     # --------------------------------------------------------------------
-    # Check Go version compatibility (benchstat requires Go 1.23+)
+    # Check Go version compatibility (benchstat requires Go 1.25+)
     # --------------------------------------------------------------------
     - name: 🔍 Check Go version compatibility
       id: version-check
@@ -67,17 +67,17 @@ runs:
         MINOR=$(echo "$GO_VERSION" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
 
         if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || ! [[ "$MAJOR" =~ ^[0-9]+$ ]] || ! [[ "$MINOR" =~ ^[0-9]+$ ]]; then
-          echo "❌ Could not parse Go version '$GO_VERSION'. Please provide a valid Go version (e.g., '1.23', '1.24.x')." >&2
+          echo "❌ Could not parse Go version '$GO_VERSION'. Please provide a valid Go version (e.g., '1.25', '1.26.x')." >&2
           exit 1
         elif [ "$MAJOR" -gt 1 ]; then
-          # Any Go major version > 1 is considered compatible with the 1.23+ requirement
-          echo "✅ Go $GO_VERSION >= 1.23: proceeding with benchstat installation"
+          # Any Go major version > 1 is considered compatible with the 1.25+ requirement
+          echo "✅ Go $GO_VERSION >= 1.25: proceeding with benchstat installation"
           echo "skip=false" >> $GITHUB_OUTPUT
-        elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 23 ]; then
-          echo "⚠️ Go $GO_VERSION < 1.23: skipping benchstat installation (requires Go 1.23+)"
+        elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 25 ]; then
+          echo "⚠️ Go $GO_VERSION < 1.25: skipping benchstat installation (requires Go 1.25+)"
           echo "skip=true" >> $GITHUB_OUTPUT
         else
-          echo "✅ Go $GO_VERSION >= 1.23: proceeding with benchstat installation"
+          echo "✅ Go $GO_VERSION >= 1.25: proceeding with benchstat installation"
           echo "skip=false" >> $GITHUB_OUTPUT
         fi
 
@@ -87,7 +87,7 @@ runs:
     - name: 💾 Restore benchstat binary cache
       if: steps.version-check.outputs.skip != 'true'
       id: benchstat-cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ~/.cache/benchstat-bin
         key: ${{ inputs.runner-os }}-benchstat-${{ inputs.benchstat-version }}
@@ -140,7 +140,7 @@ runs:
       run: |
         # Check if installation was skipped due to Go version
         if [[ "${{ steps.version-check.outputs.skip }}" == "true" ]]; then
-          echo "⏭️ Benchstat installation skipped (Go version < 1.23)"
+          echo "⏭️ Benchstat installation skipped (Go version < 1.25)"
           echo "method=skipped" >> $GITHUB_OUTPUT
           echo "📋 Installation method: Skipped"
           exit 0

--- a/.github/actions/setup-go-with-cache/action.yml
+++ b/.github/actions/setup-go-with-cache/action.yml
@@ -211,11 +211,10 @@ runs:
 
     # --------------------------------------------------------------------
     # Go module cache (shared across versions)
-    # Uses actions/cache@v4 which handles both restore and save
     # --------------------------------------------------------------------
     - name: 💾 Go module cache
       id: restore-gomod
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ~/go/pkg/mod
         key: ${{ steps.cache-keys.outputs.module-key }}
@@ -285,11 +284,10 @@ runs:
 
     # --------------------------------------------------------------------
     # Go build cache (per-version)
-    # Uses actions/cache@v4 which handles both restore and save
     # --------------------------------------------------------------------
     - name: 💾 Go build cache
       id: restore-gobuild
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build

--- a/.github/actions/setup-goreleaser/action.yml
+++ b/.github/actions/setup-goreleaser/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: 💾 Restore goreleaser binary cache
       id: goreleaser-cache
       if: steps.check-existing.outputs.exists != 'true'
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/goreleaser-bin

--- a/.github/actions/setup-mage/action.yml
+++ b/.github/actions/setup-mage/action.yml
@@ -47,7 +47,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 💾 Restore mage binary cache
       id: mage-cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ~/.cache/mage-bin
         key: ${{ inputs.runner-os }}-mage-${{ inputs.mage-version }}

--- a/.github/actions/setup-magex/action.yml
+++ b/.github/actions/setup-magex/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: 💾 Restore magex binary cache
       id: magex-cache
       if: inputs.use-local != 'true'
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/magex-bin
@@ -82,7 +82,7 @@ runs:
     - name: 💾 Restore magex binary cache (local)
       id: magex-local-cache
       if: inputs.use-local == 'true'
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/magex-local

--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -319,6 +319,15 @@ runs:
       run: |
         set -euo pipefail
         GO_MODULE_DIR="${{ env.GO_MODULE_DIR }}"
+        BUILD_STRATEGY="${MAGE_X_BUILD_STRATEGY:-smart}"
+
+        # Allow skipping pre-build entirely (useful when packages OOM on standard runners)
+        if [ "$BUILD_STRATEGY" == "skip" ]; then
+          echo "⏭️ Build pre-compilation skipped (MAGE_X_BUILD_STRATEGY=skip)"
+          echo "ℹ️  Module cache is still warmed — build cache will populate on first real build"
+          exit 0
+        fi
+
         echo "🔧 Build cache miss - pre-building packages..."
 
         echo "============================================================"
@@ -333,21 +342,21 @@ runs:
           echo "🔧 Multi-module mode - running build commands from repository root"
           echo "📦 magex will discover all Go modules and pre-build packages"
           # Use configured parallelism to avoid OOM on GitHub Actions runners
-          magex build:prebuild p="$PARALLEL_JOBS" strategy="${MAGE_X_BUILD_STRATEGY:-smart}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}"
+          magex build:prebuild p="$PARALLEL_JOBS" strategy="${BUILD_STRATEGY}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}"
 
           echo "🏗️ Building stdlib for host platform..."
           magex install:stdlib
         elif [ -n "$GO_MODULE_DIR" ]; then
           echo "🔧 Running build commands from directory: $GO_MODULE_DIR"
           # Use configured parallelism to avoid OOM on GitHub Actions runners
-          (cd "$GO_MODULE_DIR" && magex build:prebuild p="$PARALLEL_JOBS" strategy="${MAGE_X_BUILD_STRATEGY:-smart}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}")
+          (cd "$GO_MODULE_DIR" && magex build:prebuild p="$PARALLEL_JOBS" strategy="${BUILD_STRATEGY}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}")
 
           echo "🏗️ Building stdlib for host platform..."
           (cd "$GO_MODULE_DIR" && magex install:stdlib)
         else
           echo "🔧 Running build commands from repository root"
           # Use configured parallelism to avoid OOM on GitHub Actions runners
-          magex build:prebuild p="$PARALLEL_JOBS" strategy="${MAGE_X_BUILD_STRATEGY:-smart}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}"
+          magex build:prebuild p="$PARALLEL_JOBS" strategy="${BUILD_STRATEGY}" batch_size="${MAGE_X_BUILD_BATCH_SIZE:-20}" batch_delay="${MAGE_X_BUILD_BATCH_DELAY_MS:-0}" exclude="${MAGE_X_BUILD_EXCLUDE_PATTERN:-}"
 
           echo "🏗️ Building stdlib for host platform..."
           magex install:stdlib
@@ -360,7 +369,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 💾 Save Go build cache
       if: steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build
@@ -372,7 +381,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 💾 Save Go module cache
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ~/go/pkg/mod
         key: ${{ steps.cache-keys.outputs.module-key }}

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.20.8
+MAGE_X_VERSION=v1.20.11
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -71,7 +71,7 @@ MAGE_X_NANCY_VERSION=v1.2.0
 MAGE_X_STATICCHECK_VERSION=2026.1
 MAGE_X_SWAG_VERSION=v1.16.6
 MAGE_X_YAMLFMT_VERSION=v0.21.0
-MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260211190930-8161c38c6cdc
+MAGE_X_BENCHSTAT_VERSION=v0.0.0-20260312031701-16a31bc5fbd0
 MAGE_X_MAGE_VERSION=v1.16.0
 
 # ================================================================================================

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
+        uses: github/codeql-action/init@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
+        uses: github/codeql-action/autobuild@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
+        uses: github/codeql-action/analyze@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0

--- a/.github/workflows/fortress-code-quality.yml
+++ b/.github/workflows/fortress-code-quality.yml
@@ -350,7 +350,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Restore golangci-lint binary cache
         id: cache-golangci-lint-binary
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.cache/golangci-lint-bin
           key: ${{ inputs.primary-runner }}-golangci-lint-binary-${{ env.MAGE_X_GOLANGCI_LINT_VERSION }}
@@ -379,7 +379,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Cache golangci-lint build cache
         id: cache-golangci-lint-build
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.cache/go-build
           key: ${{ inputs.primary-runner }}-go-build-golangci-${{ env.MAGE_X_GOLANGCI_LINT_VERSION }}-${{ hashFiles('**/*.go') }}
@@ -391,7 +391,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Cache golangci-lint analysis
         id: cache-golangci-lint
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ env.GOLANGCI_LINT_CACHE }}
           key: ${{ inputs.primary-runner }}-golangci-lint-analysis-${{ hashFiles('.golangci.json', env.GO_SUM_FILE) }}-${{ steps.golangci-lint-version.outputs.version }}

--- a/.github/workflows/fortress-coverage.yml
+++ b/.github/workflows/fortress-coverage.yml
@@ -193,7 +193,7 @@ jobs:
       - name: 💾 Restore go-coverage binary cache (production)
         id: go-coverage-cache
         if: env.GO_COVERAGE_USE_LOCAL != 'true'
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-coverage-bin
@@ -204,7 +204,7 @@ jobs:
       - name: 💾 Restore go-coverage binary cache (local)
         id: go-coverage-local-cache
         if: env.GO_COVERAGE_USE_LOCAL == 'true'
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-coverage-local
@@ -2484,11 +2484,11 @@ jobs:
       # --------------------------------------------------------------------
       # Upload to Codecov
       # --------------------------------------------------------------------
-      # NOTE: codecov/codecov-action@v5.5.2 is the latest release and still uses Node.js 20.
+      # NOTE: codecov/codecov-action@v5.5.3 is the latest release and still uses Node.js 20.
       # This will trigger a "Node.js 20 actions are deprecated" warning until Codecov
       # releases a new version with Node.js 24 support. Expected and harmless for now.
       - name: 📈 Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
           #file: ./coverage.txt # This is the old format
           files: ./coverage-artifacts/coverage-data/coverage.txt

--- a/.github/workflows/fortress-pre-commit.yml
+++ b/.github/workflows/fortress-pre-commit.yml
@@ -115,7 +115,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Restore golangci-lint analysis cache
         id: cache-golangci-lint-analysis
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ env.GOLANGCI_LINT_CACHE }}
           key: ${{ inputs.primary-runner }}-golangci-lint-analysis-${{ hashFiles('.golangci.json', env.GO_SUM_FILE) }}-${{ env.GO_PRE_COMMIT_GOLANGCI_LINT_VERSION }}
@@ -130,7 +130,7 @@ jobs:
       - name: 💾 Restore go-pre-commit binary cache
         id: go-pre-commit-cache
         if: env.GO_PRE_COMMIT_USE_LOCAL != 'true'
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-pre-commit-bin
@@ -144,7 +144,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Restore go-pre-commit tools cache
         id: go-pre-commit-tools-cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-pre-commit-tools

--- a/.github/workflows/fortress-release.yml
+++ b/.github/workflows/fortress-release.yml
@@ -174,7 +174,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Cache golangci-lint analysis
         id: cache-golangci-lint
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ env.GOLANGCI_LINT_CACHE }}
           key: ${{ inputs.primary-runner }}-golangci-lint-analysis-${{ hashFiles('.golangci.json', env.GO_SUM_FILE) }}-${{ inputs.golangci-lint-version }}

--- a/.github/workflows/fortress-security-scans.yml
+++ b/.github/workflows/fortress-security-scans.yml
@@ -324,7 +324,7 @@ jobs:
       # --------------------------------------------------------------------
       - name: 💾 Restore govulncheck binary cache
         id: govuln-cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/govulncheck-bin

--- a/.github/workflows/fortress-test-matrix.yml
+++ b/.github/workflows/fortress-test-matrix.yml
@@ -177,7 +177,7 @@ jobs:
 
       # --------------------------------------------------------------------
       # Setup benchstat (required for benchmark comparison tests)
-      # Note: benchstat requires Go 1.23+, action will skip for older versions
+      # Note: benchstat requires Go 1.25+, action will skip for older versions
       # --------------------------------------------------------------------
       - name: 📊 Setup benchstat
         uses: ./.github/actions/setup-benchstat

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -76,6 +76,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
+        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated `actions/cache` from `v5.0.3` to `v5.0.4` (commit hash `cdf6c1fa76f9f475f3d7449005a359c84ca0f306` to `668228422ae6a00e4ad889ee87cd7109ec5666a7`) in `.github/actions/setup-go-with-cache/action.yml` for both Go module cache and Go build cache steps
* Removed comment "Uses actions/cache@v4 which handles both restore and save" from two cache-related sections in the setup-go-with-cache action
* Updated benchstat minimum Go version requirement from `1.23+` to `1.25+` in `.github/actions/setup-benchstat/action.yml`, including updates to:
  * Input description examples changing from "1.24.x, 1.22" to "1.25.x, 1.24"
  * Output description for the `skipped` field
  * Comment describing Go version compatibility check

## Why It Was Necessary

* Keeps the GitHub Actions cache dependency up to date with the latest patch release, which may include bug fixes or security improvements
* Updates benchstat action to reflect a new minimum Go version requirement, ensuring compatibility documentation is accurate
* Removes outdated comment referencing `v4` when the action is now using `v5.0.4`

## Testing Performed

* Verified that `actions/cache@v5.0.4` is a valid and released version of the GitHub Actions cache action
* Confirmed that the commit hash `668228422ae6a00e4ad889ee87cd7109ec5666a7` corresponds to the `v5.0.4` tag
* Validated that all documentation and description updates for benchstat are internally consistent (input descriptions, output descriptions, and comments all reference Go 1.25+)

## Impact / Risk

* **Breaking Change**: The benchstat action will now skip installation for Go versions below 1.25 (previously 1.23), which may affect workflows using older Go versions
* **Risk**: Low for the cache action update - patch version bump from v5.0.3 to v5.0.4 should be backwards compatible
* **Dependencies**: Workflows relying on benchstat with Go 1.23 or 1.24 will need to update their Go version to 1.25+ or accept that benchstat installation will be skipped

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 16
  files_with_original_content: 16
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: ffbafef459958ad6e405b1bb183b82fd1358f78e
  target_repo: mrz1836/go-logger
  sync_commit: 94ebfdd05ab7071f58abd74e5db9cfd262db2018
  sync_time: 2026-03-20T10:50:55-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 982
  - src: .github/actions
    dest: .github/actions
    files_synced: 7
    files_examined: 18
    files_excluded: 0
    processing_time_ms: 1550
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 509
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 800
  - src: .github/scripts
    dest: .github/scripts
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 402
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 644
  - src: .github/workflows
    dest: .github/workflows
    files_synced: 8
    files_examined: 26
    files_excluded: 0
    processing_time_ms: 938
  - src: .vscode
    dest: .vscode
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 321
performance:
  total_files: 101
-->
