### PR TITLE
[Sync] Update project files from source repository (0f07170)

### DIFF
--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -267,7 +267,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for module download (module cache miss)
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
@@ -306,7 +306,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for build warming (module hit, build miss)
       if: steps.setup-go.outputs.module-cache-hit == 'true' && steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
        &nbsp;&nbsp;&nbsp;&nbsp; <code>Quality</code> &nbsp;&nbsp;
     </td>
     <td align="left">
-       <a href="https://goreportcard.com/report/github.com/mrz1836/go-logger"><img src="https://goreportcard.com/badge/github.com/mrz1836/go-logger?style=flat-square" alt="Go Report"></a>
        <a href="https://codecov.io/gh/mrz1836/go-logger"><img src="https://codecov.io/gh/mrz1836/go-logger/branch/master/graph/badge.svg?style=flat-square" alt="Coverage"></a>
     </td>
   </tr>

--- a/gorm.go
+++ b/gorm.go
@@ -111,7 +111,8 @@ func (l *basicGormLogger) Trace(_ context.Context, begin time.Time, fc func() (s
 	switch {
 	case err != nil && l.logLevel >= Error && (!strings.Contains(err.Error(), "record not found")):
 		sql, rows := fc()
-		Data(l.stackLevel, ERROR,
+		Data(
+			l.stackLevel, ERROR,
 			"error executing query",
 			MakeParameter("file", fileWithLineNum()),
 			MakeParameter("error", err.Error()),
@@ -121,7 +122,8 @@ func (l *basicGormLogger) Trace(_ context.Context, begin time.Time, fc func() (s
 		)
 	case elapsed > SlowQueryThreshold && l.logLevel >= Warn:
 		sql, rows := fc()
-		Data(l.stackLevel, WARN,
+		Data(
+			l.stackLevel, WARN,
 			"warning executing query",
 			MakeParameter("file", fileWithLineNum()),
 			MakeParameter("slow_log", fmt.Sprintf("SLOW SQL >= %v", SlowQueryThreshold)),
@@ -131,7 +133,8 @@ func (l *basicGormLogger) Trace(_ context.Context, begin time.Time, fc func() (s
 		)
 	case l.logLevel == Info:
 		sql, rows := fc()
-		Data(l.stackLevel, INFO,
+		Data(
+			l.stackLevel, INFO,
 			"executing sql query",
 			MakeParameter("file", fileWithLineNum()),
 			MakeParameter("duration", fmt.Sprintf("%.3fms", float64(elapsed.Nanoseconds())/1e6)),

--- a/gorm_fuzz_test.go
+++ b/gorm_fuzz_test.go
@@ -21,19 +21,27 @@ type testLoggerImpl struct {
 }
 
 func (t *testLoggerImpl) Fatal(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
+
 func (t *testLoggerImpl) Fatalf(format string, v ...interface{}) {
 	t.messages = append(t.messages, fmt.Sprintf(format, v...))
 }
+
 func (t *testLoggerImpl) Fatalln(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
-func (t *testLoggerImpl) Panic(v ...interface{})   { t.messages = append(t.messages, fmt.Sprint(v...)) }
+
+func (t *testLoggerImpl) Panic(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
+
 func (t *testLoggerImpl) Panicf(s string, v ...interface{}) {
 	t.messages = append(t.messages, fmt.Sprintf(s, v...))
 }
+
 func (t *testLoggerImpl) Panicln(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
-func (t *testLoggerImpl) Print(v ...interface{})   { t.messages = append(t.messages, fmt.Sprint(v...)) }
+
+func (t *testLoggerImpl) Print(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
+
 func (t *testLoggerImpl) Printf(format string, v ...interface{}) {
 	t.messages = append(t.messages, fmt.Sprintf(format, v...))
 }
+
 func (t *testLoggerImpl) Println(v ...interface{}) { t.messages = append(t.messages, fmt.Sprint(v...)) }
 
 func FuzzNewGormLogger(f *testing.F) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -9,12 +9,22 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testFileTag is the "<dir>/logger_test.go" prefix FileTag/FileTagComponents
+// produce for this file, derived from the checkout's actual directory name
+// rather than hardcoded, since that name varies across checkouts/CI runners.
+var testFileTag = func() string { //nolint:gochecknoglobals // computed once for reuse across many test assertions in this file
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Base(filepath.Dir(file)) + "/logger_test.go"
+}()
 
 // captureOutput captures the output of log, fmt or os.Stderr.WriteString
 func captureOutput(f func()) string {
@@ -91,7 +101,7 @@ func BenchmarkLogLevel_String(b *testing.B) {
 func TestFileTag(t *testing.T) {
 	// File tag
 	fileTag := FileTag(1)
-	assert.Contains(t, fileTag, "go-logger/logger_test.go:go-logger.TestFileTag:")
+	assert.Contains(t, fileTag, testFileTag+":go-logger.TestFileTag:")
 }
 
 // ExampleFileTag example using FileTag()
@@ -131,7 +141,7 @@ func TestFileTagComponents(t *testing.T) {
 	assert.Len(t, fileTagComps, 3)
 
 	// Test the part
-	assert.Equal(t, "go-logger/logger_test.go", fileTagComps[0])
+	assert.Equal(t, testFileTag, fileTagComps[0])
 
 	// Test the part
 	assert.Equal(t, "go-logger.TestFileTagComponents", fileTagComps[1])
@@ -140,8 +150,8 @@ func TestFileTagComponents(t *testing.T) {
 // ExampleFileTagComponents example using FileTagComponents()
 func ExampleFileTagComponents() {
 	fileTag := FileTagComponents(1)
-	fmt.Println(fileTag[0])
-	// Output:go-logger/logger_test.go
+	fmt.Println(filepath.Base(fileTag[0]))
+	// Output:logger_test.go
 }
 
 // BenchmarkFileTaComponents benchmarks the FileTagComponents() method
@@ -157,7 +167,7 @@ func TestPrintln(t *testing.T) {
 		Println("test this method")
 	})
 
-	assert.Contains(t, captured, "go-logger/logger_test.go:go-logger.TestPrintln")
+	assert.Contains(t, captured, testFileTag+":go-logger.TestPrintln")
 	assert.Contains(t, captured, "test this method")
 }
 
@@ -167,7 +177,7 @@ func TestPrint(t *testing.T) {
 		Print("test this method")
 	})
 
-	assert.Contains(t, captured, "go-logger/logger_test.go:go-logger.TestPrint")
+	assert.Contains(t, captured, testFileTag+":go-logger.TestPrint")
 	assert.Contains(t, captured, "test this method")
 }
 
@@ -192,7 +202,7 @@ func TestPrintf(t *testing.T) {
 		Printf("test this method: %s", "TestPrintf")
 	})
 
-	assert.Contains(t, captured, "go-logger/logger_test.go:go-logger.TestPrintf")
+	assert.Contains(t, captured, testFileTag+":go-logger.TestPrintf")
 	assert.Contains(t, captured, "test this method: TestPrintf")
 }
 
@@ -218,7 +228,7 @@ func TestErrorln(t *testing.T) {
 		Errorln(2, "test this method")
 	})
 
-	assert.Contains(t, captured, "go-logger/logger_test.go:go-logger.TestErrorln")
+	assert.Contains(t, captured, testFileTag+":go-logger.TestErrorln")
 	assert.Contains(t, captured, "test this method")
 }
 
@@ -235,7 +245,7 @@ func TestErrorfmt(t *testing.T) {
 		Errorfmt(2, "test this method: %s", "Errorfmt")
 	})
 
-	assert.Contains(t, captured, "go-logger/logger_test.go:go-logger.TestErrorfmt")
+	assert.Contains(t, captured, testFileTag+":go-logger.TestErrorfmt")
 	assert.Contains(t, captured, "test this method: Errorfmt")
 }
 
@@ -258,7 +268,7 @@ func TestData(t *testing.T) {
 	assert.Contains(t, captured, `type="warn"`)
 
 	// Check for file
-	assert.Contains(t, captured, `file="go-logger/logger_test.go"`)
+	assert.Contains(t, captured, fmt.Sprintf(`file="%s"`, testFileTag))
 
 	// Check for method
 	assert.Contains(t, captured, `method="go-logger.TestData.func1"`)


### PR DESCRIPTION
## What Changed

* Updated `actions/checkout` action from `v7.0.0` (commit `9c091bb`) to `v7.0.1` (commit `3d3c42e`) in `.github/actions/warm-cache/action.yml` (2 occurrences)
* Updated `github/codeql-action/init` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/autobuild` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/analyze` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/upload-sarif` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/scorecard.yml`

## Why It Was Necessary

* Patch version updates to GitHub Actions typically include bug fixes, security improvements, or minor enhancements
* Keeping GitHub Actions up to date ensures the CI/CD pipeline benefits from the latest fixes and maintains security best practices
* CodeQL action updates may include improved detection rules or analysis performance improvements

## Testing Performed

* CI workflows will automatically validate the updated actions when this PR is opened
* Existing test suites will run against the updated GitHub Actions versions
* CodeQL analysis, cache warming, and scorecard workflows will execute with the new action versions to verify compatibility

## Impact / Risk

* **Breaking Change**: None - these are patch version updates to GitHub Actions
* **Risk**: Very low - patch updates are designed to be backwards compatible and only include bug fixes
* **Performance**: No negative impact expected; CodeQL updates may improve analysis performance

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 3
  files_with_original_content: 3
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 0f0717087ae0c640cd7648815a15736f770debaf
  target_repo: mrz1836/go-logger
  sync_commit: 5c119c1c11727127c87aa09010c06099b3046f9e
  sync_time: 2026-07-23T07:58:39-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 765
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1047
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 246
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 609
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 393
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 758
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 2
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 799
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 332
performance:
  total_files: 103
-->
